### PR TITLE
feat(types)!: separate partial information about channel into own struct

### DIFF
--- a/channels_test.go
+++ b/channels_test.go
@@ -23,7 +23,7 @@ func TestClient_Channels_Create(t *testing.T) {
 		&ClientCategoryChannels{c: c},
 		"Create",
 		[]any{types.ChannelTypePrivate, map[string]any{"do_you_like_waffles": true}, "", WithProjectID("test123")},
-		&types.Channel{ID: "hello"})
+		&types.Channel{ChannelPartial: types.ChannelPartial{ID: "hello"}})
 }
 
 func TestClient_Channels_Get(t *testing.T) {
@@ -40,7 +40,7 @@ func TestClient_Channels_Get(t *testing.T) {
 		&ClientCategoryChannels{c: c},
 		"Get",
 		[]any{"test test", WithProjectID("test123")},
-		&types.Channel{ID: "hello"})
+		&types.Channel{ChannelPartial: types.ChannelPartial{ID: "hello"}})
 }
 
 func TestClient_Channels_GetAll(t *testing.T) {

--- a/types/channels.go
+++ b/types/channels.go
@@ -14,25 +14,31 @@ const (
 	ChannelTypeUnprotected ChannelType = "unprotected"
 )
 
-// Channel is used to define the main structure of a channel.
-type Channel struct {
+// ChannelPartial is used to define a partial channel. Whilst currently not used by the hop-go library,
+// this may be desirable for things importing the types package such as a leap client.
+type ChannelPartial struct {
 	// ID is the ID of the channel.
 	ID string `json:"id"`
 
-	// Project is the project it is associated with.
-	Project *Project `json:"project"`
-
 	// State is any state metadata associated with the channel.
 	State map[string]any `json:"state"`
+
+	// Type is the type of this channel.
+	Type ChannelType `json:"type"`
+}
+
+// Channel is used to define the main structure of a channel.
+type Channel struct {
+	ChannelPartial `json:",inline"`
+
+	// Project is the project it is associated with.
+	Project *Project `json:"project"`
 
 	// Capabilities is the capabilities of this channel.
 	Capabilities int `json:"capabilities"`
 
 	// CreatedAt is when this channel was created.
 	CreatedAt Timestamp `json:"created_at"`
-
-	// Type is the type of this channel.
-	Type ChannelType `json:"type"`
 }
 
 // Stats is used to define the stats for a channel.

--- a/types/testdata/types.Channel.json
+++ b/types/testdata/types.Channel.json
@@ -1,29 +1,29 @@
 {
 	"id": "abc",
-	"project": {
-		"id": "def",
-		"name": "ghi",
-		"tier": "jkl",
-		"created_at": "mno",
-		"icon": "pqr",
-		"namespace": "stu",
-		"type": "vwx",
-		"default_quotas": {
-			"vcpu": 8,
-			"ram": 9
-		},
-		"quota_overrides": {
-			"abc": 11
-		},
-		"quota_usage": {
-			"vcpu": 12,
-			"ram": 13
-		}
-	},
 	"state": {
 		"def": "ghi"
 	},
-	"capabilities": 16,
-	"created_at": "jkl",
-	"type": "mno"
+	"type": "jkl",
+	"project": {
+		"id": "mno",
+		"name": "pqr",
+		"tier": "stu",
+		"created_at": "vwx",
+		"icon": "abc",
+		"namespace": "def",
+		"type": "ghi",
+		"default_quotas": {
+			"vcpu": 11,
+			"ram": 12
+		},
+		"quota_overrides": {
+			"jkl": 14
+		},
+		"quota_usage": {
+			"vcpu": 15,
+			"ram": 16
+		}
+	},
+	"capabilities": 17,
+	"created_at": "mno"
 }

--- a/types/testdata/types.ChannelPartial.json
+++ b/types/testdata/types.ChannelPartial.json
@@ -1,0 +1,7 @@
+{
+	"id": "abc",
+	"state": {
+		"def": "ghi"
+	},
+	"type": "jkl"
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -15,6 +15,7 @@ var types = []reflect.Type{
 	// channels.go
 	reflect.TypeOf(ChannelType("")),
 	reflect.TypeOf(Channel{}),
+	reflect.TypeOf(ChannelPartial{}),
 	reflect.TypeOf(Stats{}),
 	reflect.TypeOf(ChannelToken{}),
 


### PR DESCRIPTION
The rationale for this is to make it so that other clients (such ass clients for Leap) can reuse this library without needing to duplicate parts that are used in different aspects of the API. This is a breaking change for people creating their own Channel instances. However, the scope of this should be limited.